### PR TITLE
fix: HTTPS for latest videos thumbnails

### DIFF
--- a/src/reducers/latestVideos.js
+++ b/src/reducers/latestVideos.js
@@ -21,7 +21,7 @@ function mapRSSItemToGame(items) {
                 "title": item.title,
                 "url": item.link,
                 "url_type": "VIDEO",
-                "imagePath": "http://i.ytimg.com/vi_webp/" + videoId + "/0.webp",
+                "imagePath": "https://i.ytimg.com/vi_webp/" + videoId + "/0.webp",
             }
         });
 }


### PR DESCRIPTION
Mixed Content: The page at '<URL>' was loaded over HTTPS, but requested an insecure element '<URL>'. This request was automatically upgraded to HTTPS
https://blog.chromium.org/2019/10/no-more-mixed-messages-about-https.html